### PR TITLE
add  enable sequential cpu offload

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -59,8 +59,9 @@ def main(args):
     pipeline.scheduler.customized_step = customized_step.__get__(pipeline.scheduler)
     pipeline.scheduler.added_set_timesteps = set_timesteps.__get__(pipeline.scheduler)
     # use low vram
-    pipeline.enable_sequential_cpu_offload()
-    
+    if args.use_cpu_offload:
+        pipeline.enable_sequential_cpu_offload()
+        
     seed = config.get("seed", args.default_seed)
     set_all_seed(seed)
     generator = torch.Generator(device=pipeline.device)
@@ -117,6 +118,7 @@ if __name__ == "__main__":
     parser.add_argument("--W", type=int, default=512)
     parser.add_argument("--H", type=int, default=512)
     parser.add_argument("--without-xformers", action="store_true")
+    parser.add_argument("--use_cpu_offload", action="store_true")
 
     args = parser.parse_args()
     main(args)

--- a/sample.py
+++ b/sample.py
@@ -58,6 +58,8 @@ def main(args):
     
     pipeline.scheduler.customized_step = customized_step.__get__(pipeline.scheduler)
     pipeline.scheduler.added_set_timesteps = set_timesteps.__get__(pipeline.scheduler)
+    # use low vram
+    pipeline.enable_sequential_cpu_offload()
     
     seed = config.get("seed", args.default_seed)
     set_all_seed(seed)


### PR DESCRIPTION
Hello, thank you for your wonderful work! When I tried to run the code, I found that the video memory overhead exceeded 40G #5, which is beyond the tolerance of most ordinary users' vram. You can consider using [enable_sequential_cpu_offload()](https://huggingface.co/docs/diffusers/optimization/memory#model-offloading) provided by the diffusers library to reduce the inference vram consumption by increasing the inference time.